### PR TITLE
Fix a bug with feature labels

### DIFF
--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -217,7 +217,7 @@ function initMyTransitLines() {
 			labelText = labelText.replace(/&apos;/g,'\'');
 			if(vectors.features[i]) vectors.features[i].attributes = { name: labelText };
 		}
-		$('#features-label-data').val(vectorLabelsData);
+		$('#mtl-feature-labels-data').val(vectorLabelsData);
 	}
 	
 	// GeoJSON import handling


### PR DESCRIPTION
When putting three points and naming the first 'A,B,C', then saving the proposal, opening it and saving again, then the Name would split up with the first point now labeled 'A', the second 'B' and the third 'C'. That was because of this typo