### PR TITLE
Fix issue #4

### DIFF
--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -376,7 +376,7 @@ function setToolPreferences() {
 			}
 		});
 	});*/
-	$('.olEditorControlDrawPointItemInactive, .olEditorControlDrawPathItemInactive, .olControlModifyFeatureItemInactive, .olControlNavigationItemInactive').click(function(){
+	$('.olEditorControlDrawPointItemInactive, .olEditorControlDrawPathItemInactive, .olControlModifyFeatureItemInactive, .olControlNavigationItemInactive, .olEditorControlDragFeatureItemInactive').click(function(){
 		unselectAllFeatures();
 	});
 	$('#feature-textinput').keypress(function(e){


### PR DESCRIPTION
Previously you could save the proposal while something was still selected, which lead to the so-called 'Haltestellenbug' happening. Now when selecting the move-tool updateFeaturesData() is called which stops this bug from happening.