### PR TITLE
Save feature data after a feature was moved 

### DIFF
--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -327,13 +327,13 @@ function changeLinetype(vectorsLayer,iconSize,lineWidth) {
 // create event handlers
 function vectorsEvents() {
 	vectors.events.on({
-		'featureadded': function() { updateFeaturesData('added') },
-		'featuremodified': function() { updateFeaturesData('modified') },
-		'featureremoved': function() { updateFeaturesData('removed') },
-		'featureselected': function() { updateFeaturesData('selected') },
-		'featureunselected': function() { updateFeaturesData('unselected') },
-		'beforefeatureremoved': function() { updateFeaturesData('beforeremoved') },
-		'afterfeaturemodified': function() { updateFeaturesData('aftermodified') }, // triggered after a feature was moved
+		'featureadded': function() { updateFeaturesData('added') }, // triggered after a feature was added
+		'featuremodified': function() { updateFeaturesData('modified') }, // triggered after part of a feature was modified by the modify-tool
+		'featureremoved': function() { updateFeaturesData('removed') }, // triggered after a feature was removed
+		'featureselected': function() { updateFeaturesData('selected') }, // triggered when selecting a feature with the select-tool
+		'featureunselected': function() { updateFeaturesData('unselected') }, // triggered when unselecting a feature with the select-tool or when automatically being unselected when selecting a different tool or setting a label
+		'beforefeatureremoved': function() { updateFeaturesData('beforeremoved') }, // triggered right before a feature is removed
+		'afterfeaturemodified': function() { updateFeaturesData('aftermodified') }, // triggered after a feature was moved or after a feature is no longer "selected" by modify-tool
 	});
 }
 

--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -333,6 +333,7 @@ function vectorsEvents() {
 		'featureselected': function() { updateFeaturesData('selected') },
 		'featureunselected': function() { updateFeaturesData('unselected') },
 		'beforefeatureremoved': function() { updateFeaturesData('beforeremoved') },
+		'afterfeaturemodified': function() { updateFeaturesData('aftermodified') }, // triggered after a feature was moved
 	});
 }
 

--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -332,7 +332,6 @@ function vectorsEvents() {
 		'featureremoved': function() { updateFeaturesData('removed') }, // triggered after a feature was removed
 		'featureselected': function() { updateFeaturesData('selected') }, // triggered when selecting a feature with the select-tool
 		'featureunselected': function() { updateFeaturesData('unselected') }, // triggered when unselecting a feature with the select-tool or when automatically being unselected when selecting a different tool or setting a label
-		'beforefeatureremoved': function() { updateFeaturesData('beforeremoved') }, // triggered right before a feature is removed
 		'afterfeaturemodified': function() { updateFeaturesData('aftermodified') }, // triggered after a feature was moved or after a feature is no longer "selected" by modify-tool
 	});
 }


### PR DESCRIPTION
Before this, no event was triggered when moving a feature, which meant that if your last change was moving a feature, that change wouldn't save. With this change updateFeaturesData() is also run after moving a feature, fixing this bug.

Also added comments that document what event is triggered by which action exactly.