### PR TITLE
Hopefully fix searching in mtl-tile-list

### DIFF
--- a/modules/mtl-tile-list/mtl-tile-list.php
+++ b/modules/mtl-tile-list/mtl-tile-list.php
@@ -94,7 +94,7 @@ function mtl_tile_list_output($atts) {
 			$status[] = 'draft';
 		}
 
-		$search = $_GET['s'];
+		$search = $_GET['search'];
 		
 		$query_string = array(
 			'posts_per_page' => $posts_per_page,
@@ -193,7 +193,7 @@ function mtl_tile_list_output($atts) {
 		$output .= '<option'.($order_by=='rand' ? ' selected="selected"' : '').' value="rand">'.__('Random','my-transit-lines').'</option>';
 		$output .= '</select><select name="order"><option'.($order=='desc' ? ' selected="selected"' : '').' value="desc">'.__('Descendent','my-transit-lines').'</option><option'.($order=='asc' ? ' selected="selected"' : '').' value="asc">'.__('Ascendent','my-transit-lines').'</option></select></p>';
 		
-		$output .= '<p><strong>'.__('Search:','my-transit-lines').'</strong><input type="search" name="s" value="'.$search.'">';
+		$output .= '<p><strong>'.__('Search:','my-transit-lines').'</strong><input type="search" name="search" value="'.$search.'">';
 
 		$output .= '<button type="submit">'.__('Filter/sort','my-transit-lines').'</button></p></form></div>'."\r\n";
 		


### PR DESCRIPTION
Change search URL parameter name from s to search.
For some reason this fixes searching, probably because the s parameter has a default use.