### PR TITLE
Fix zoom setting

### DIFF
--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -32,6 +32,7 @@ if(typeof OpenLayers != 'undefined') var projmerc = new OpenLayers.Projection("E
 var newLabelCollection = [];
 var mtlCenterLon = 0;
 var mtlCenterLat = 0;
+var mtlStandardZoom = 0;
 var initMap = true;
 var importFilename = '';
 
@@ -185,8 +186,8 @@ function initMyTransitLines() {
 	var lonlat = new OpenLayers.LonLat(mtlCenterLon,mtlCenterLat);
 	lonlat.transform(proj4326, projmerc);
 	
-	// center map to Hamburg
-	map.setCenter(lonlat, 13);
+	// center map to the default from the settings
+	map.setCenter(lonlat, mtlStandardZoom);
 	map.addControl(new OpenLayers.Control.ScaleLine({bottomOutUnits: '',maxWidth: 200, geodesic: true}));
 	
 	// load vector data from WKT string

--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -627,6 +627,9 @@ function initMyTransitLinesDashboard() {
 		if($('input#mtl-center-lat').length) $('input#mtl-center-lat').on('change propertychange paste',function(){
 			changeMapMarker();
 		});
+		if($('input#mtl-standard-zoom').length) $('input#mtl-standard-zoom').on('change propertychange paste',function(){
+			changeMapMarker();
+		});
 	}
 	
 	// handle image upload fields
@@ -699,17 +702,16 @@ function addAdminMapCenter() {
 	var layerOSM = new OpenLayers.Layer.OSM();
 	admin_map.addLayer( layerOSM );
 	admin_map.setCenter(new OpenLayers.LonLat(0,0).transform(proj4326,projmerc), 1);
-	
-	// get current center position as marker if exists
-	if(mapCenterLon != '' && mapCenterLat != '') {
-		var lonLat = new OpenLayers.LonLat(mapCenterLon,mapCenterLat).transform(proj4326,projmerc);
-		admin_map.setCenter (lonLat, 12);
-	}
 	  
 	markers = new OpenLayers.Layer.Markers( "Markers" );
     admin_map.addLayer(markers);
-	  
-	if(mapCenterLon != '' && mapCenterLat != '') markers.addMarker(new OpenLayers.Marker(lonLat));
+	
+	// get current center position as marker if exists
+	if(mapCenterLon != '' && mapCenterLat != '' && mapStandardZoom != '') {
+		var lonLat = new OpenLayers.LonLat(mapCenterLon,mapCenterLat).transform(proj4326,projmerc);
+		markers.addMarker(new OpenLayers.Marker(lonLat));
+		admin_map.setCenter(lonLat, mapStandardZoom);
+	}
 	
 	admin_map.events.register("click", admin_map, function(evt) {
 		markers.clearMarkers();
@@ -722,6 +724,11 @@ function addAdminMapCenter() {
 		$('#mtl-center-lat').val(pos.lat);
 		
 	});
+
+	admin_map.events.register("moveend", admin_map, function(evt) {
+		var currentZoom = admin_map.getZoom();
+		$('#mtl-standard-zoom').val(currentZoom);
+	});
 }
 
 function changeMapMarker() {
@@ -730,14 +737,17 @@ function changeMapMarker() {
 	markers.clearMarkers();
 	var currentLon = parseFloat($('input#mtl-center-lon').val());
 	var currentLat = parseFloat($('input#mtl-center-lat').val());
+	var currentZoom = parseInt($('input#mtl-standard-zoom').val());
 	var pos = new OpenLayers.LonLat(currentLon,currentLat);
 	pos.transform(proj4326,projmerc);
 	marker = new OpenLayers.Marker(pos);
 	markers.addMarker(marker);
 	admin_map.setCenter(pos);
+	admin_map.zoomTo(currentZoom);
 	pos.transform(projmerc,proj4326);
 	$('#mtl-center-lon').val(pos.lon);
 	$('#mtl-center-lat').val(pos.lat);
+	$('#mtl-standard-zoom').val(currentZoom);
 }
 
 function manipulateTitle(newTitle) {

--- a/modules/mtl-admin-menu/mtl-admin-menu.class.php
+++ b/modules/mtl-admin-menu/mtl-admin-menu.class.php
@@ -334,7 +334,7 @@ class MtlSettingsPage
 		
 		echo '<script type="text/javascript" src="'.get_template_directory_uri().'/openlayers/OpenLayers.js"></script>'."\r\n";
 		echo '<div id="mtl-admin-map-center"></div>'."\r\n";
-		echo '<script type="text/javascript"> var mapCenterLon = '.($mtl_options['mtl-center-lon'] ? $mtl_options['mtl-center-lon'] : '0').'; var mapCenterLat = '.($mtl_options['mtl-center-lat'] ? $mtl_options['mtl-center-lat'] : '0').'; </script>'."\r\n";
+		echo '<script type="text/javascript"> var mapCenterLon = '.($mtl_options['mtl-center-lon'] ? $mtl_options['mtl-center-lon'] : '0').'; var mapCenterLat = '.($mtl_options['mtl-center-lat'] ? $mtl_options['mtl-center-lat'] : '0').'; var mapStandardZoom = '.($mtl_options['mtl-standard-zoom'] ? $mtl_options['mtl-standard-zoom'] : '6').'; </script>'."\r\n";
     }
 	
     public function print_map_section_content2() {

--- a/modules/mtl-proposal-form/mtl-proposal-form.php
+++ b/modules/mtl-proposal-form/mtl-proposal-form.php
@@ -319,7 +319,7 @@ function mtl_proposal_form_output( $atts ){
 			$output .= '<script type="text/javascript" src="'.get_template_directory_uri() . '/ole/lib/loader.js"></script>'."\r\n";
 			$output .= mtl_localize_script(true);
 			$output .= '<script type="text/javascript" src="'.get_template_directory_uri() . '/js/my-transit-lines.js"></script>'."\r\n";
-			$output .= '<script type="text/javascript"> '.$output_later.' var mtlCenterLon = "'.$mtl_options['mtl-center-lon'].'"; var mtlCenterLat = "'.$mtl_options['mtl-center-lat'].'"; </script>'."\r\n";
+			$output .= '<script type="text/javascript"> '.$output_later.' var mtlCenterLon = "'.$mtl_options['mtl-center-lon'].'"; var mtlCenterLat = "'.$mtl_options['mtl-center-lat'].'"; var mtlStandardZoom = '.$mtl_options['mtl-standard-zoom'].'; </script>'."\r\n";
 		
 			// select transit mode and add map data for post type "mtlproposal"
 			if($postType == 'mtlproposal') {


### PR DESCRIPTION
Currently the zoom setting doesn't have any effect on the zoom level of the map when a new proposal is being edited. This PR fixes that. It changes:

- The PHP scripts that now pass down the setting to the js script
- The admin menu map where location and zoom of the map can be set that now shows the current zoom setting and the other way round
- The map when editing a new proposal to actually use the correct zoom level