### PR TITLE
Add GeoJSON export for drafts

### DIFF
--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -18,7 +18,7 @@ var graphicZIndexSelected = 5;
 if(typeof themeUrl != 'undefined') var externalGraphicUrl = '';
 if(typeof themeUrl != 'undefined') var externalGraphicUrlSelected = '';
 var label = '';
-var wkt;
+const WKT_FORMAT = new OpenLayers.Format.WKT();
 var warningMessage = '';
 var bahnTyp;
 var stationSelected = -1;
@@ -188,9 +188,6 @@ function initMyTransitLines() {
 	// center map to Hamburg
 	map.setCenter(lonlat, 13);
 	map.addControl(new OpenLayers.Control.ScaleLine({bottomOutUnits: '',maxWidth: 200, geodesic: true}));
-	
-	// load vector data from WKT string
-	wkt = new OpenLayers.Format.WKT();
 
 	if(vectorData) {
 		if(vectorData.includes('POINT') || vectorData.includes('LINESTRING')) {
@@ -591,7 +588,7 @@ function featuresToWKT(features) {
  * @returns features[]
  */
 function WKTtoFeatures(vectorData) {
-	features = wkt.read(vectorData);
+	features = WKT_FORMAT.read(vectorData);
 	if(features.constructor != Array) {
 		features = [features];
 	}
@@ -824,9 +821,6 @@ function importToMap(result) {
 				}								
 			}
 			
-			// output WKT format
-			let WKTFormat = new OpenLayers.Format.WKT();
-			
 			// parse GeoJSON to WKT. Selfmade! TODO: Simplify & cleanup.
 			let WKTFeatures = 'GEOMETRYCOLLECTION(';
 			let firstFeature = true;
@@ -869,7 +863,7 @@ function importToMap(result) {
 				if(WKTFeatures.includes('POINT') || WKTFeatures.includes('LINESTRING') || WKTFeatures.includes('MULTILINESTRING')) {
 					var oldFeatures = vectors.features;
 					vectors.removeAllFeatures();
-					features = wkt.read(WKTFeatures);
+					features = WKT_FORMAT.read(WKTFeatures);
 					if(features.constructor != Array) {
 						features = [features];
 					}

--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -194,10 +194,7 @@ function initMyTransitLines() {
 
 	if(vectorData) {
 		if(vectorData.includes('POINT') || vectorData.includes('LINESTRING')) {
-			features = wkt.read(vectorData);
-			if(features.constructor != Array) {
-				features = [features];
-			}
+			features = WKTtoFeatures(vectorData);
 			countFeatures = features.length;
 			vectors.addFeatures(features);
 			for(var i =0; i < vectors.features.length; i++) vectors.features[i].geometry.transform(proj4326,projmerc);
@@ -585,6 +582,20 @@ function featuresToWKT(features) {
 	}
 
 	return ['GEOMETRYCOLLECTION('+featuresData+')',featuresLabelData.join()];
+}
+
+/**
+ * Returns the array of features, does nothing else
+ * 
+ * @param {*} vectorData 
+ * @returns features[]
+ */
+function WKTtoFeatures(vectorData) {
+	features = wkt.read(vectorData);
+	if(features.constructor != Array) {
+		features = [features];
+	}
+	return features;
 }
 
 // unselect vector features and write new label, when point feature was selected

--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -537,6 +537,38 @@ function updateFeaturesData(changeType) {
 		var transformedFeature = vectors.features[i].geometry.transform(projmerc,proj4326);
 		if(featureString.includes('LINESTRING')) lineLength = lineLength + transformedFeature.getGeodesicLength();
 		
+		vectors.features[i].geometry.transform(proj4326,projmerc);
+	}
+
+	var wkt_strings = featuresToWKT(vectors.features);
+	
+	// write WKT features data to html element (will be saved to database on form submit)
+	var collection = wkt_strings[0];
+	var labelCollection = wkt_strings[1];
+	$('#mtl-feature-data').val(collection);
+	$('#mtl-feature-labels-data').val(labelCollection);
+	$('#mtl-count-stations').val(countStations);
+	$('#mtl-line-length').val(lineLength);
+	
+	if(changeType == 'added' || changeType == 'modified') lastFeatureLabels = labelCollection
+	
+	// only redraw vectors when 'modify' tool not selected (prevent overwriting of styles for feature modification)
+	if(!$('.olControlModifyFeatureItemActive').length) vectors.redraw();
+}
+
+/**
+ * Returns an array of two strings: the first one is the geometry data, the second one the label data
+ * 
+ * @param {*} features 
+ * @returns string[]
+ */
+function featuresToWKT(features) {
+	featuresData = [];
+	featuresLabelData = [];
+
+	for (var i = 0; i < features.length; i++) {
+		var transformedFeature = vectors.features[i].geometry.transform(projmerc,proj4326);
+		
 		if(i < countFeatures) {
 			// write all features data to array as WKT
 			featuresData.push(transformedFeature.toString());
@@ -551,19 +583,8 @@ function updateFeaturesData(changeType) {
 		
 		vectors.features[i].geometry.transform(proj4326,projmerc);
 	}
-	
-	// write WKT features data to html element (will be saved to database on form submit)
-	var collection = 'GEOMETRYCOLLECTION('+featuresData+')';
-	var labelCollection = featuresLabelData.join();
-	$('#mtl-feature-data').val(collection);
-	$('#mtl-feature-labels-data').val(labelCollection);
-	$('#mtl-count-stations').val(countStations);
-	$('#mtl-line-length').val(lineLength);
-	
-	if(changeType == 'added' || changeType == 'modified') lastFeatureLabels = labelCollection
-	
-	// only redraw vectors when 'modify' tool not selected (prevent overwriting of styles for feature modification)
-	if(!$('.olControlModifyFeatureItemActive').length) vectors.redraw();
+
+	return ['GEOMETRYCOLLECTION('+featuresData+')',featuresLabelData.join()];
 }
 
 // unselect vector features and write new label, when point feature was selected

--- a/modules/mtl-download-geojson/mtl-download-geojson.js
+++ b/modules/mtl-download-geojson/mtl-download-geojson.js
@@ -1,32 +1,38 @@
-var geojson_options = {};
-var feature_labels_data_for_geojson_array = feature_labels_data_for_geojson.split(',');
-var wkt_format = new OpenLayers.Format.WKT();
-var wkt_features = wkt_format.read(feature_data_for_geojson);
-var wkt_options = {};
-var geojson_format = new OpenLayers.Format.GeoJSON(wkt_options);
-var prepare1 = geojson_format.write(wkt_features);
-var prepare2 = JSON.parse(prepare1);
-prepare2.name = title_for_geojson;
-prepare2.description = content_for_geojson;
-prepare2.author = author_for_geojson;
-prepare2.date = date_for_geojson;
-prepare2.transit_mode = category_for_geojson;
-prepare2.original_website = website_for_geojson;
-prepare2.license_link = license_link_for_geojson;
-for(var i = 0;i<prepare2.features.length;i++) {
-	if(prepare2.features[i].geometry.type=='Point') {
-		prepare2.features[i].properties.name = feature_labels_data_for_geojson_array[i];
-		prepare2.features[i].properties.description = category_for_geojson+"\n"+author_for_geojson+"\n"+date_for_geojson+"\n"+website_for_geojson+"\n"+license_link_for_geojson;
+function getGeoJSON() {
+	var wkt_strings = featuresToWKT(vectors.features);
+	var feature_data_for_geojson = wkt_strings[0];
+	var feature_labels_data_for_geojson = wkt_strings[1];
+
+	var geojson_options = {};
+	var feature_labels_data_for_geojson_array = feature_labels_data_for_geojson.split(',');
+	var wkt_format = new OpenLayers.Format.WKT();
+	var wkt_features = wkt_format.read(feature_data_for_geojson);
+	var wkt_options = {};
+	var geojson_format = new OpenLayers.Format.GeoJSON(wkt_options);
+	var prepare1 = geojson_format.write(wkt_features);
+	var prepare2 = JSON.parse(prepare1);
+	prepare2.name = title_for_geojson;
+	prepare2.description = content_for_geojson;
+	prepare2.author = author_for_geojson;
+	prepare2.date = date_for_geojson;
+	prepare2.transit_mode = category_for_geojson;
+	prepare2.original_website = website_for_geojson;
+	prepare2.license_link = license_link_for_geojson;
+	for(var i = 0;i<prepare2.features.length;i++) {
+		if(prepare2.features[i].geometry.type=='Point') {
+			prepare2.features[i].properties.name = feature_labels_data_for_geojson_array[i];
+			prepare2.features[i].properties.description = category_for_geojson+"\n"+author_for_geojson+"\n"+date_for_geojson+"\n"+website_for_geojson+"\n"+license_link_for_geojson;
+		}
+		if(prepare2.features[i].geometry.type=='LineString') {
+			prepare2.features[i].properties.name = title_for_geojson;
+			prepare2.features[i].properties.description = content_for_geojson+"\n\n"+category_for_geojson+"\n"+author_for_geojson+"\n"+date_for_geojson+"\n"+website_for_geojson+"\n"+license_link_for_geojson;
+		}
 	}
-	if(prepare2.features[i].geometry.type=='LineString') {
-		prepare2.features[i].properties.name = title_for_geojson;
-		prepare2.features[i].properties.description = content_for_geojson+"\n\n"+category_for_geojson+"\n"+author_for_geojson+"\n"+date_for_geojson+"\n"+website_for_geojson+"\n"+license_link_for_geojson;
-	}
+	return JSON.stringify(prepare2);
 }
-var geojson_ready = JSON.stringify(prepare2);
 
 window.onload = function() {
   document.getElementById('mtl-geojson-download').onclick = function() {
-	this.href = 'data:text/json;charset=utf-8,'+encodeURIComponent(geojson_ready);
+	this.href = 'data:text/json;charset=utf-8,'+encodeURIComponent(getGeoJSON());
   };
 };

--- a/modules/mtl-download-geojson/mtl-download-geojson.php
+++ b/modules/mtl-download-geojson/mtl-download-geojson.php
@@ -14,30 +14,39 @@
  
 function download_GeoJSON($content) {
 	global $post;
+
 	if(is_single()) {
-		$featureData = get_post_meta($post->ID,'mtl-feature-data',true);
-		if($featureData) {
-			$featureLabelsData = get_post_meta($post->ID,'mtl-feature-labels-data',true);
-			$output = '';
-			$output .= '
-		<script type="text/javascript">
-			var feature_data_for_geojson = "'.$featureData.'";
-			var feature_labels_data_for_geojson = "'.$featureLabelsData.'";
-			var title_for_geojson = "'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title()))).'";
-			var content_for_geojson = "'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_content()))).'";
-			var author_for_geojson = "'.get_the_author().'";
-			var date_for_geojson = "'.get_the_date().'";
-			var website_for_geojson = "'.get_bloginfo('url').'";';
-	$category = get_the_category($post->ID);
-			$output .= '
-			var category_for_geojson = "'.$category[0]->name.'";
-			var license_link_for_geojson = "https://creativecommons.org/licenses/by-nc-sa/3.0/de/";
-		</script>
-		<script type="text/javascript" src="'.get_template_directory_uri().'/modules/mtl-download-geojson/mtl-download-geojson.js"></script>
-		<p><a href="" download="'.$post->ID.'-'.$post->post_name.'.geojson" id="mtl-geojson-download">'.__('Download proposal map data as GeoJSON','my-transit-lines').'</a></p>';
-			$content .= $output;
-		}
+		$content .= get_download_button($post->ID);
+	} else if (is_page(get_option('mtl-option-name')['mtl-addpost-page'])) {
+		$content .= get_download_button(get_editId());
 	}
+
 	return $content;
 }
 add_filter('the_content','download_GeoJSON');
+
+function get_download_button($postId) {
+	$output = '';
+
+	$featureData = get_post_meta($postId,'mtl-feature-data',true);
+	if($featureData) {
+		$featureLabelsData = get_post_meta($postId,'mtl-feature-labels-data',true);
+		$category = get_the_category($postId);
+		$output .= '
+	<script type="text/javascript">
+		var feature_data_for_geojson = "'.$featureData.'";
+		var feature_labels_data_for_geojson = "'.$featureLabelsData.'";
+		var title_for_geojson = "'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title($postId)))).'";
+		var content_for_geojson = "'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_content(null, false, $postId)))).'";
+		var author_for_geojson = "'.get_the_author($postId).'";
+		var date_for_geojson = "'.get_the_date('', $postId).'";
+		var website_for_geojson = "'.get_bloginfo('url').'";
+		var category_for_geojson = "'.$category[0]->name.'";
+		var license_link_for_geojson = "https://creativecommons.org/licenses/by-nc-sa/3.0/de/";
+		</script>
+		<script type="text/javascript" src="'.get_template_directory_uri().'/modules/mtl-download-geojson/mtl-download-geojson.js"></script>
+		<p><a href="" download="'.$postId.'-'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title($postId)))).'.geojson" id="mtl-geojson-download">'.__('Download proposal map data as GeoJSON','my-transit-lines').'</a></p>';
+	}
+
+	return $output;
+}

--- a/modules/mtl-download-geojson/mtl-download-geojson.php
+++ b/modules/mtl-download-geojson/mtl-download-geojson.php
@@ -28,10 +28,8 @@ add_filter('the_content','download_GeoJSON');
 function get_download_button($postId) {
 	$output = '';
 
-	$featureData = get_post_meta($postId,'mtl-feature-data',true);
-	if($featureData) {
-		$featureLabelsData = get_post_meta($postId,'mtl-feature-labels-data',true);
-		$category = get_the_category($postId);
+	$category = get_the_category($postId);
+	if($category) {
 		$output .= '
 	<script type="text/javascript">
 		var title_for_geojson = "'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title($postId)))).'";

--- a/modules/mtl-download-geojson/mtl-download-geojson.php
+++ b/modules/mtl-download-geojson/mtl-download-geojson.php
@@ -34,8 +34,6 @@ function get_download_button($postId) {
 		$category = get_the_category($postId);
 		$output .= '
 	<script type="text/javascript">
-		var feature_data_for_geojson = "'.$featureData.'";
-		var feature_labels_data_for_geojson = "'.$featureLabelsData.'";
 		var title_for_geojson = "'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title($postId)))).'";
 		var content_for_geojson = "'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_content(null, false, $postId)))).'";
 		var author_for_geojson = "'.get_the_author($postId).'";


### PR DESCRIPTION
This PR changes:

- mtl-proposal-form to have more things separated into their own functions to make them reusable, most notably getEditId()
- my-transit-lines.js to have the conversion between WKT and map features as separate reusable functions
- mtl-download-geojson to both accept finished and draft proposals and to get the geojson data from the current features on the map instead of the saved WKT data