### PR TITLE
Set allowed html tags manually

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -526,3 +526,23 @@ function mtl_filter_media_comment_status( $open, $post_id ) {
     return $open;
 }
 add_filter( 'comments_open', 'mtl_filter_media_comment_status', 10 , 2 );
+
+function allowed_html_tags() {
+    return array(
+        'a' => array(
+            'href' => true,
+            'title' => true,
+        ),
+		'blockquote' => array(),
+        'br' => array(),
+        'code' => array(),
+		'del' => array(),
+        'em' => array(),
+		'li' => array(),
+		'ol' => array(),
+        'p' => array(),
+        'strong' => array(),
+		'ul' => array(),
+    );
+}
+add_filter( 'wp_kses_allowed_html', 'allowed_html_tags', 1 );


### PR DESCRIPTION
Includes all the usual formatting but also lists. 'code' tag isn't like <script> and doesn't allow anything to be executed, so it is fine under XSS standpoints