### PR TITLE
Add script after the download button

### DIFF
--- a/modules/mtl-download-geojson/mtl-download-geojson.php
+++ b/modules/mtl-download-geojson/mtl-download-geojson.php
@@ -40,8 +40,8 @@ function get_download_button($postId) {
 		var category_for_geojson = "'.$category[0]->name.'";
 		var license_link_for_geojson = "https://creativecommons.org/licenses/by-nc-sa/3.0/de/";
 		</script>
-		<script type="text/javascript" src="'.get_template_directory_uri().'/modules/mtl-download-geojson/mtl-download-geojson.js"></script>
-		<p><a href="" download="'.$postId.'-'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title($postId)))).'.geojson" id="mtl-geojson-download">'.__('Download proposal map data as GeoJSON','my-transit-lines').'</a></p>';
+		<p><a href="" download="'.$postId.'-'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title($postId)))).'.geojson" id="mtl-geojson-download">'.__('Download proposal map data as GeoJSON','my-transit-lines').'</a></p>
+		<script type="text/javascript" src="'.get_template_directory_uri().'/modules/mtl-download-geojson/mtl-download-geojson.js"></script>';
 	}
 
 	return $output;


### PR DESCRIPTION
For some reason for me locally the GeoJSON download worked, while in production it doesn't. With this change the event listener for the button should only be added after the button is already loaded.