### PR TITLE
Add checkbox to hide station labels

### DIFF
--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -32,6 +32,7 @@ var mtlCenterLat = 0;
 var mtlStandardZoom = 0;
 var initMap = true;
 var importFilename = '';
+var labelsHidden = false;
 
 //Notify the user when about to leave page without saving changes
 $(window).bind('beforeunload', function() {
@@ -257,7 +258,7 @@ function initMyTransitLines() {
 
 function changeLinetype() {
 	for (i = 0; i < vectors.features.length; i++) {
-		setFeatureStyle(i, vectors.selectedFeatures.includes(vectors.features[i]), getCategoryOf(vectors.features[i]));
+		setFeatureStyle(i, vectors.selectedFeatures.includes(vectors.features[i]), getCategoryOf(vectors.features[i]), !labelsHidden);
 	}
 	setToolPreferences();
 	unselectAllFeatures();
@@ -428,7 +429,7 @@ function onFeatureAdded() {
 		$('#feature-textinput').val('');
 	}
 
-	setFeatureStyle(vectors.features.length - 1, false, getCategoryOf(vectors.features[vectors.features.length - 1]));
+	setFeatureStyle(vectors.features.length - 1, false, getCategoryOf(vectors.features[vectors.features.length - 1]), !labelsHidden);
 
 	vectors.redraw();
 
@@ -480,7 +481,7 @@ function onFeatureSelected() {
 			stationSelected = realIndex;
 		}
 		
-		setFeatureStyle(realIndex, true, getCategoryOf(vectors.selectedFeatures[i]));
+		setFeatureStyle(realIndex, true, getCategoryOf(vectors.selectedFeatures[i]), !labelsHidden);
 	}
 
 	vectors.redraw();
@@ -509,7 +510,7 @@ function onFeatureUnselected() {
 	}
 
 	for (i = 0; i < vectors.features.length; i++) {
-		setFeatureStyle(i, vectors.selectedFeatures.includes(vectors.features[i]), getCategoryOf(vectors.features[i]));
+		setFeatureStyle(i, vectors.selectedFeatures.includes(vectors.features[i]), getCategoryOf(vectors.features[i]), !labelsHidden);
 	}
 
 	vectors.redraw();
@@ -642,8 +643,9 @@ function getSelectedCategory() {
  * @param {number} featureIndex which feature to set the style of
  * @param {boolean} selected if the feature is selected
  * @param {number} categoryId which category the feature has
+ * @param {boolean} showLabel whether the label should be shown
  */
-function setFeatureStyle(featureIndex, selected, categoryId) {
+function setFeatureStyle(featureIndex, selected, categoryId, showLabel) {
 	categoryColor = transportModeStyleData[categoryId][0];
 
 	if (vectors.features[featureIndex].geometry instanceof OpenLayers.Geometry.Point) {
@@ -652,7 +654,7 @@ function setFeatureStyle(featureIndex, selected, categoryId) {
 			graphicHeight: selected ? graphicHeightSelected : graphicHeightUnselected,
 			graphicWidth: selected ? graphicWidthSelected : graphicWidthUnselected,
 			graphicZIndex: selected ? graphicZIndexSelected : graphicZIndexUnselectedPoint,
-			label: vectors.features[featureIndex].attributes.name,
+			label: showLabel ? vectors.features[featureIndex].attributes.name : "",
 			fontColor: 'white',
 			fontSize: "11px",
 			fontWeight: "bold",
@@ -714,6 +716,13 @@ function loadNewFeatures() {
 		}
 		zoomToFeatures();
 	}
+	changeLinetype();
+}
+
+// toggles whether the labels get shown on the map or not
+function toggleLabels() {
+	labelsHidden = !labelsHidden;
+
 	changeLinetype();
 }
 

--- a/modules/mtl-multiple-proposal/mtl-multiple-proposal.php
+++ b/modules/mtl-multiple-proposal/mtl-multiple-proposal.php
@@ -196,10 +196,13 @@ function mtl_multiple_proposal_output( $atts ) {
 		$output .= '<div id="mtl-map"></div>'."\r\n";
 		$output .= '</div>';
 
-		// output opacity change button and map fullscreen link
+		// output opacity change button, map fullscreen link and toggle label checkbox
 		$output .= '<p id="map-color-opacity"><span id="mtl-colored-map-box"><label for="mtl-colored-map"><input type="checkbox" checked="checked" id="mtl-colored-map" name="colored-map" onclick="setMapColors()" /> '.__('colored map','my-transit-lines').'</label></span> &nbsp; <span id="mtl-opacity-low-box"><label for="mtl-opacity-low"><input type="checkbox" checked="checked" id="mtl-opacity-low" name="opacity-low" onclick="setMapOpacity()" /> '.__('brightened map','my-transit-lines').'</label></span></p>'."\r\n";
 		$output .= '<p class="alignright"><a id="mtl-fullscreen-link" href="javascript:mtlFullscreenMap()"><span class="fullscreen-closed">'.__('Fullscreen view','my-transit-lines').'</span><span class="fullscreen-open">'.__('Close fullscreen view','my-transit-lines').'</span></a></p>'."\r\n";
+		$output .= '<p class="alignright" id="mtl-toggle-labels"><label><input type="checkbox" checked="checked" id="mtl-toggle-labels-link" onclick="toggleLabels()" /> '.__('Show labels','my-transit-lines').'</label></p>'."\r\n";
 		$output .= '</div>'."\r\n";
+
+		$output .= '<script type="text/javascript"> $(document).ready(function(){ document.getElementById("mtl-toggle-labels-link").checked = false; toggleLabels();}); </script>'."\r\n";
 
 		$output .= '<script type="text/javascript"> var post_list_url = "'.get_permalink(get_option('mtl-option-name')['mtl-postlist-page']).'"; </script><p class="alignleft"> <a id="mtl-post-list-link">'.__('Proposal list page','my-transit-lines').'</a> </p>';
     }

--- a/modules/mtl-single-proposal/mtl-single-proposal.php
+++ b/modules/mtl-single-proposal/mtl-single-proposal.php
@@ -60,9 +60,10 @@ function mtl_proposal_map($content) {
 		$output .= '<div id="mtl-map"></div>'."\r\n";
 		$output .= '</div>';
 		
-		// output opacity change button and map fullscreen link
+		// output opacity change button, map fullscreen link and toggle label checkbox
 		$output .= '<p id="map-color-opacity"><span id="mtl-colored-map-box"><label for="mtl-colored-map"><input type="checkbox" checked="checked" id="mtl-colored-map" name="colored-map" onclick="setMapColors()" /> '.__('colored map','my-transit-lines').'</label></span> &nbsp; <span id="mtl-opacity-low-box"><label for="mtl-opacity-low"><input type="checkbox" checked="checked" id="mtl-opacity-low" name="opacity-low" onclick="setMapOpacity()" /> '.__('brightened map','my-transit-lines').'</label></span></p>'."\r\n";
 		$output .= '<p class="alignright"><a id="mtl-fullscreen-link" href="javascript:mtlFullscreenMap()"><span class="fullscreen-closed">'.__('Fullscreen view','my-transit-lines').'</span><span class="fullscreen-open">'.__('Close fullscreen view','my-transit-lines').'</span></a></p>'."\r\n";
+		$output .= '<p class="alignright" id="mtl-toggle-labels"><label><input type="checkbox" checked="checked" id="mtl-toggle-labels-link" onclick="toggleLabels()" /> '.__('Show labels','my-transit-lines').'</label></p>'."\r\n";
 		$output .= '</div>'."\r\n";
 		
 		// output the meta data


### PR DESCRIPTION
Adds a checkbox to hide/show the station labels beneath the map on both single and multiple proposal views. By default it is checked in single proposal view and unchecked in multiple proposal view.