### PR TITLE
Zoom to default when no features are present

### DIFF
--- a/js/my-transit-lines.js
+++ b/js/my-transit-lines.js
@@ -175,7 +175,6 @@ function initMyTransitLines() {
 	map.addLayer(vectors);
 	
 	// projection transformation
-
 	var lonlat = new OpenLayers.LonLat(mtlCenterLon,mtlCenterLat);
 	lonlat.transform(proj4326, projmerc);
 	
@@ -743,10 +742,18 @@ function mtlFullscreenMap() {
 function zoomToFeatures(mapId,vectorsLayer) {
 	if(!mapId) mapId = map;
 	if(!vectorsLayer) vectorsLayer = vectors;
-	var bounds = vectorsLayer.getDataExtent();
-	mapId.zoomToExtent(bounds);
-	if(mapId.getZoom()>14) mapId.setCenter(bounds.getCenterLonLat(),14);
-	else mapId.setCenter(bounds.getCenterLonLat());
+	try {
+		var bounds = vectorsLayer.getDataExtent();
+		mapId.zoomToExtent(bounds);
+		if(mapId.getZoom()>14) mapId.setCenter(bounds.getCenterLonLat(),14);
+		else mapId.setCenter(bounds.getCenterLonLat());
+	} catch (error) {
+		var lonlat = new OpenLayers.LonLat(mtlCenterLon,mtlCenterLat);
+		lonlat.transform(proj4326, projmerc);
+		
+		// center map to the default from the settings
+		mapId.setCenter(lonlat, mtlStandardZoom);
+	}
 	if($('#zoomtofeatures').length) $('#zoomtofeatures a').blur();
 }
 


### PR DESCRIPTION
This would give an exception previously zooming to 0,0, now it zooms to the default position of the map from the settings