### PR TITLE
Fix wp import

### DIFF
--- a/modules/mtl-download-geojson/mtl-download-geojson.js
+++ b/modules/mtl-download-geojson/mtl-download-geojson.js
@@ -21,11 +21,6 @@ function getGeoJSON() {
 	for(var i = 0;i<prepare2.features.length;i++) {
 		if(prepare2.features[i].geometry.type=='Point') {
 			prepare2.features[i].properties.name = feature_labels_data_for_geojson_array[i];
-			prepare2.features[i].properties.description = category_for_geojson+"\n"+author_for_geojson+"\n"+date_for_geojson+"\n"+website_for_geojson+"\n"+license_link_for_geojson;
-		}
-		if(prepare2.features[i].geometry.type=='LineString') {
-			prepare2.features[i].properties.name = title_for_geojson;
-			prepare2.features[i].properties.description = content_for_geojson+"\n\n"+category_for_geojson+"\n"+author_for_geojson+"\n"+date_for_geojson+"\n"+website_for_geojson+"\n"+license_link_for_geojson;
 		}
 	}
 	return JSON.stringify(prepare2);

--- a/modules/mtl-multiple-proposal/mtl-multiple-proposal.php
+++ b/modules/mtl-multiple-proposal/mtl-multiple-proposal.php
@@ -105,8 +105,9 @@ function mtl_multiple_proposal_output( $atts ) {
 			$catid = $category[0]->cat_ID;
 
 			array_push($vector_categories_data, $catid);
-			array_push($vector_data, get_post_meta($post->ID,'mtl-feature-data',true));
-			array_push($vector_labels_data, get_post_meta($post->ID,'mtl-feature-labels-data',true));
+			// Removing line breaks that can be caused by WordPress import/export
+			array_push($vector_data, str_replace("\n", "", get_post_meta($post->ID,'mtl-feature-data',true)));
+			array_push($vector_labels_data, str_replace("\n", "", get_post_meta($post->ID,'mtl-feature-labels-data',true)));
 		}
 
 		endwhile;

--- a/modules/mtl-single-proposal/mtl-single-proposal.php
+++ b/modules/mtl-single-proposal/mtl-single-proposal.php
@@ -48,7 +48,8 @@ function mtl_proposal_map($content) {
 		$output .= "\r";
 		$output .= '<div id="mtl-box">'."\r\n";
 		$output .= '<script type="text/javascript"> var transportModeStyleData = {'.$catid.' : ["'.$mtl_options['mtl-color-cat'.$catid].'","'.$mtl_options['mtl-image-cat'.$catid].'","'.$mtl_options['mtl-image-selected-cat'.$catid].'"]}; </script>';
-		$output .= '<script type="text/javascript"> var themeUrl = "'. get_template_directory_uri() .'"; var vectorData = ["'.get_post_meta($post->ID,'mtl-feature-data',true).'"]; var vectorLabelsData = ["'.get_post_meta($post->ID,'mtl-feature-labels-data',true).'"]; var vectorCategoriesData = [undefined]; var editMode = false; </script>'."\r\n";
+		// Removing line breaks that can be caused by WordPress import/export
+		$output .= '<script type="text/javascript"> var themeUrl = "'. get_template_directory_uri() .'"; var vectorData = ["'.str_replace("\n", "", get_post_meta($post->ID,'mtl-feature-data',true)).'"]; var vectorLabelsData = ["'.str_replace("\n", "", get_post_meta($post->ID,'mtl-feature-labels-data',true)).'"]; var vectorCategoriesData = [undefined]; var editMode = false; </script>'."\r\n";
 		$output .= '<script type="text/javascript" src="'.get_template_directory_uri().'/openlayers/OpenLayers.js"></script>'."\r\n";
 		$output .= '<script type="text/javascript" src="'.get_template_directory_uri() . '/ole/lib/Editor/Lang/de.js"></script>'."\r\n";
 		$output .= '<script type="text/javascript" src="'.get_template_directory_uri() . '/ole/lib/loader.js"></script>'."\r\n";

--- a/modules/mtl-tile-list/mtl-tile-list.php
+++ b/modules/mtl-tile-list/mtl-tile-list.php
@@ -270,7 +270,8 @@ function mtl_tile_list_output($atts) {
 			$output .= '<div class="mtl-post-tile" style="background-color:'.$bgcolor.'" >';
 			
 			if(!$hidethumbs) {
-				$output .= '<script type="text/javascript"> var currentCat = '.$catid.'; var pluginsUrl = "'. plugins_url('', __FILE__) .'"; var vectorData = ["'.get_post_meta($post->ID,'mtl-feature-data',true).'"]; var vectorLabelsData = ["'.get_post_meta($post->ID,'mtl-feature-labels-data',true).'"]; var vectorCategoriesData = [undefined]; var editMode = false; </script>'."\r\n";
+				// Removing line breaks that can be caused by WordPress import/export
+				$output .= '<script type="text/javascript"> var currentCat = '.$catid.'; var pluginsUrl = "'. plugins_url('', __FILE__) .'"; var vectorData = ["'.str_replace("\n", "", get_post_meta($post->ID,'mtl-feature-data',true)).'"]; var vectorLabelsData = ["'.str_replace("\n", "", get_post_meta($post->ID,'mtl-feature-labels-data',true)).'"]; var vectorCategoriesData = [undefined]; var editMode = false; </script>'."\r\n";
 				$output .= mtl_thumblist_map();
 			}
 			$output .= mtl_load_template_part( 'content', get_post_format() );


### PR DESCRIPTION
Line breaks that appear when exporting and importing proposal data would cause errors in the javascript, so they're removed before they get there. Doesn't change anything in normal circumstances