### PR TITLE
Version 2.11.0: Add meta field revisions

### DIFF
--- a/modules/common.php
+++ b/modules/common.php
@@ -78,18 +78,24 @@ function get_searchable_categories() {
 /**
  * Returns a JSON string with all the relevant data of the specified proposal
  * @param int $post_id the id of the proposal
+ * @param int $revision the meta revision of the proposal
  * @return string the JSON data or the empty string if the given post_id was invalid
  */
-function get_proposal_data_json($post_id) {
+function get_proposal_data_json($post_id, $revision = -1) {
 	if (!is_numeric($post_id) || !get_post_status($post_id))
 		return '';
+
+	if (!is_numeric($revision) || $revision < 0 || $revision >= get_post_meta( $post_id, 'mtl-meta-revision', true ) || !current_user_can('administrator')) {
+		$features = str_replace(["\n", "\r", "\\"], "", get_post_meta($post_id, 'mtl-features', true));
+	} else {
+		$features = str_replace(["\n", "\r", "\\"], "", get_post_meta($post_id, '_'.$revision.'mtl-features', true));
+	}
 
 	$author = get_the_author_meta('display_name', get_post_field ('post_author', $post_id));
 	$title = get_the_title($post_id);
 	$date = get_the_date('d.m.Y', $post_id);
 	$link = get_permalink_or_edit($post_id);
 	$catid = get_the_category($post_id)[0]->term_id;
-	$features = str_replace(["\n", "\r", "\\"], "", get_post_meta($post_id, 'mtl-features', true));
 	$status = get_post_status($post_id);
 
 	return '{"id":'.$post_id.',"author":"'.$author.'","title":"'.$title.'","date":"'.$date.'","link":"'.$link.'","category":'.$catid.',"features":"'.$features.'","status":"'.$status.'"}';

--- a/modules/mtl-metaboxes/mtl-metaboxes.php
+++ b/modules/mtl-metaboxes/mtl-metaboxes.php
@@ -96,12 +96,16 @@ function mtl_post_class_meta_box($post) {
 	$output .= '<input type="hidden" id="mtl-features" value="'.$mtl_features.'" name="mtl-features" />'."\r\n";
 	
 	// hidden input field for station count
-	$mtl_count_stations =  get_post_meta($post->ID,'mtl-count-stations',true);
+	$mtl_count_stations = get_post_meta($post->ID,'mtl-count-stations',true);
 	$output .= '<input type="hidden" id="mtl-count-stations" value="'.$mtl_count_stations.'"  name="mtl-count-stations" />'."\r\n";
 	
 	// hidden input field for line length
-	$mtl_line_length =  get_post_meta($post->ID,'mtl-line-length',true);
+	$mtl_line_length = get_post_meta($post->ID,'mtl-line-length',true);
 	$output .= '<input type="hidden" id="mtl-line-length" value="'.$mtl_line_length.'"  name="mtl-line-length" />'."\r\n";
+
+	// hidden input field for costs
+	$mtl_costs = get_post_meta($post->ID,'mtl-costs',true);
+	$output .= '<input type="hidden" id="mtl-costs" value="'.$mtl_costs.'"  name="mtl-costs" />'."\r\n";
 	
 	echo $output;
 }
@@ -122,8 +126,17 @@ function mtl_post_save($post_id) {
 	
 	// saving custom fields
 	if(!isset($_POST['mtl-manual-proposal-data']) || $_POST['mtl-manual-proposal-data'] != 'on') {
-		$save_custom_fields = array('mtl-features','mtl-count-stations','mtl-line-length');
-		foreach($save_custom_fields as $save_custom_field) if($_POST[$save_custom_field] != get_post_meta($post_id,$save_custom_field,true)) update_post_meta($post_id,$save_custom_field,$_POST[$save_custom_field]);
+		$save_custom_fields = array('mtl-features','mtl-count-stations','mtl-line-length','mtl-costs');
+		if (has_meta_changed($post_id)) {
+			$meta_revision = intval(get_post_meta($post_id, 'mtl-meta-revision', true) ?: 0);
+
+			update_post_meta($post_id, 'mtl-meta-revision', $meta_revision + 1);
+
+			foreach($save_custom_fields as $save_custom_field) {
+				update_post_meta($post_id,'_'.$meta_revision.$save_custom_field,$_POST[$save_custom_field]);
+				update_post_meta($post_id,$save_custom_field,$_POST[$save_custom_field]);
+			}
+		}
 		
 		if($_POST['cat']) {
 			remove_action( 'save_post', 'mtl_post_save' ); // remove save action to avoid infinite loop
@@ -135,8 +148,6 @@ function mtl_post_save($post_id) {
 			add_action( 'save_post', 'mtl_post_save' ); // re-add save action
 		}
 	}
-	
-	
 }
 add_action('save_post','mtl_post_save');
 

--- a/modules/mtl-proposal-form/mtl-proposal-form.php
+++ b/modules/mtl-proposal-form/mtl-proposal-form.php
@@ -128,12 +128,23 @@ function mtl_proposal_form_output( $atts ){
 					else $realip = getenv('REMOTE_ADDR');
 				}
 
-				// update/add all other needed post meta
 				update_post_meta($current_post_id, 'mtl-author-ip', $realip);
-				update_post_meta($current_post_id, 'mtl-count-stations', $_POST['mtl-count-stations']);
-				update_post_meta($current_post_id, 'mtl-line-length', $_POST['mtl-line-length']);
-				update_post_meta($current_post_id, 'mtl-features', $_POST['mtl-features']);
-				update_post_meta($current_post_id, 'mtl-costs', $_POST['mtl-costs']);
+
+				if (has_meta_changed($current_post_id)) {
+					$meta_revision = intval(get_post_meta($current_post_id, 'mtl-meta-revision', true) ?: 0);
+
+					update_post_meta($current_post_id, '_'.$meta_revision.'mtl-count-stations', get_post_meta($current_post_id, 'mtl-count-stations', true));
+					update_post_meta($current_post_id, '_'.$meta_revision.'mtl-line-length', get_post_meta($current_post_id, 'mtl-line-length', true));
+					update_post_meta($current_post_id, '_'.$meta_revision.'mtl-features', get_post_meta($current_post_id, 'mtl-features', true));
+					update_post_meta($current_post_id, '_'.$meta_revision.'mtl-costs', get_post_meta($current_post_id, 'mtl-costs', true));
+
+					// update/add all other needed post meta
+					update_post_meta($current_post_id, 'mtl-meta-revision', $meta_revision + 1);
+					update_post_meta($current_post_id, 'mtl-count-stations', $_POST['mtl-count-stations']);
+					update_post_meta($current_post_id, 'mtl-line-length', $_POST['mtl-line-length']);
+					update_post_meta($current_post_id, 'mtl-features', $_POST['mtl-features']);
+					update_post_meta($current_post_id, 'mtl-costs', $_POST['mtl-costs']);
+				}
 
 				do_action('wp_insert_post', $current_post_id, get_post($current_post_id), true);
 				
@@ -516,6 +527,16 @@ function get_id() {
  */
 function is_form_allowed() {
 	return is_user_logged_in() && (is_edit() || get_more_drafts_allowed());
+}
+
+/**
+ * Returns true iff a meta field value in $_POST has changed in regards to the currently saved values
+ */
+function has_meta_changed($post_id) {
+	return trim($_POST['mtl-costs']) != trim(addslashes(get_post_meta( $post_id, 'mtl-costs', true )))
+		|| trim($_POST['mtl-features']) != trim(addslashes(get_post_meta( $post_id, 'mtl-features', true )))
+		|| trim($_POST['mtl-line-length']) != trim(addslashes(get_post_meta( $post_id, 'mtl-line-length', true )))
+		|| trim($_POST['mtl-count-stations']) != trim(addslashes(get_post_meta( $post_id, 'mtl-count-stations', true)));
 }
 
  /**

--- a/modules/mtl-proposal-form/mtl-proposal-form.php
+++ b/modules/mtl-proposal-form/mtl-proposal-form.php
@@ -135,9 +135,6 @@ function mtl_proposal_form_output( $atts ){
 				update_post_meta($current_post_id, 'mtl-features', $_POST['mtl-features']);
 				update_post_meta($current_post_id, 'mtl-costs', $_POST['mtl-costs']);
 
-				delete_post_meta($current_post_id, 'mtl-feature-data');
-				delete_post_meta($current_post_id, 'mtl-feature-labels-data');
-				
 				do_action('wp_insert_post', $current_post_id, get_post($current_post_id), true);
 				
 				// enable/disable contact button for current user

--- a/modules/mtl-single-proposal/mtl-single-proposal.php
+++ b/modules/mtl-single-proposal/mtl-single-proposal.php
@@ -30,7 +30,7 @@ function mtl_proposal_map($content) {
 	<script type="text/javascript">
 		var editMode = false;
 		var themeUrl = "'.get_template_directory_uri().'";
-		var proposalList = ['.get_proposal_data_json($post->ID).']
+		var proposalList = ['.get_proposal_data_json($post->ID, $_GET['r'] ?? -1).']
 	</script>'.
 	get_transport_mode_style_data().
 	mtl_localize_script(true).

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://stadtkreation.de/en/wordpress-themes-and-plugins/
 Author: Stadtkreation
 Author URI: https://stadtkreation.de/en/about-us/
 Description: "My Transit Lines" is a Wordpress theme developed for urban and regional public transit platforms. Follow the theme link to find out more. New additions since version 1.0: Rating tool added, minor bugs fixed, GeoJSON download added.
-Version: 2.10.0
+Version: 2.11.0
 Tested up to: 6.6.1
 Requires PHP: 7.4
 License: GNU General Public License v2 or later


### PR DESCRIPTION
Map features will now be saved as a sort of custom revisions. When viewing a proposal as an admin, you can see different meta revisions by specifying r=number as an URL parameter.