### PR TITLE
Version 2.11.5-2.11.6: Don't reload on extern links and fix replys

### DIFF
--- a/modules/mtl-single-proposal/mtl-single-proposal.js
+++ b/modules/mtl-single-proposal/mtl-single-proposal.js
@@ -85,7 +85,7 @@ function add_event_listeners() {
 			const link_path = link_url.pathname.substring(1).split('/');
 			const location_path = window.location.pathname.substring(1).split('/');
 
-			if (link_path.length > 0 && location_path.length > 0 && link_path[0] === location_path[0]) {
+			if (link_url.pathname !== window.location.pathname && link_path.length > 0 && location_path.length > 0 && link_path[0] === location_path[0]) {
 				link.dataset.mtlNoReload = "";
 
 				if (link_url.host.startsWith('extern.')) {

--- a/modules/mtl-single-proposal/mtl-single-proposal.js
+++ b/modules/mtl-single-proposal/mtl-single-proposal.js
@@ -81,12 +81,25 @@ function add_event_listeners() {
 	document.querySelectorAll('a:not([data-mtl-no-reload])').forEach(link => {
 		const link_url = new URL(link);
 
-		if (link_url.host === window.location.host || 'extern.'+link_url.host === window.location.host) {
+		if (link_url.host === window.location.host || link_url.host === 'extern.'+window.location.host) {
 			const link_path = link_url.pathname.substring(1).split('/');
 			const location_path = window.location.pathname.substring(1).split('/');
 
 			if (link_path.length > 0 && location_path.length > 0 && link_path[0] === location_path[0]) {
 				link.dataset.mtlNoReload = "";
+
+				if (link_url.host.startsWith('extern.')) {
+					link_url.host = link_url.host.substring('extern.'.length);
+					link.href = link_url.toString();
+				}
+
+				if (!link.href.startsWith('https://')) {
+					if (link.href.startsWith('http://')) {
+						link.href = link.href.replace('http://', 'https://');
+					} else {
+						link.href = 'https://' + link.href;
+					}
+				}
 			}
 		}
 	});

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://stadtkreation.de/en/wordpress-themes-and-plugins/
 Author: Stadtkreation
 Author URI: https://stadtkreation.de/en/about-us/
 Description: "My Transit Lines" is a Wordpress theme developed for urban and regional public transit platforms. Follow the theme link to find out more. New additions since version 1.0: Rating tool added, minor bugs fixed, GeoJSON download added.
-Version: 2.11.5
+Version: 2.11.6
 Tested up to: 6.6.1
 Requires PHP: 7.4
 License: GNU General Public License v2 or later

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://stadtkreation.de/en/wordpress-themes-and-plugins/
 Author: Stadtkreation
 Author URI: https://stadtkreation.de/en/about-us/
 Description: "My Transit Lines" is a Wordpress theme developed for urban and regional public transit platforms. Follow the theme link to find out more. New additions since version 1.0: Rating tool added, minor bugs fixed, GeoJSON download added.
-Version: 2.11.4
+Version: 2.11.5
 Tested up to: 6.6.1
 Requires PHP: 7.4
 License: GNU General Public License v2 or later


### PR DESCRIPTION
Now this actually checks for the link URL to be extern.linieplus.de

Also you can reply to comments again.