### PR TITLE
Version 2.13.6: Fix GeoJSON bug with shortcodes

### DIFF
--- a/modules/mtl-download-geojson/mtl-download-geojson.js
+++ b/modules/mtl-download-geojson/mtl-download-geojson.js
@@ -12,8 +12,12 @@ function getGeoJSON() {
 	return JSON.stringify(featuresDataObject);
 }
 
-window.addEventListener('load', function() {
-	document.getElementById('mtl-geojson-download').onclick = function() {
+document.getElementById('mtl-geojson-download').onclick = function(event) {
+	try {
 		this.href = 'data:text/json;charset=utf-8,'+encodeURIComponent(getGeoJSON());
-	};
-});
+	} catch (e) {
+		console.log(e);
+		alert("Something has gone wrong while generating the GeoJSON. Please contact the administrator of the Website!");
+		event.preventDefault();
+	}
+};

--- a/modules/mtl-download-geojson/mtl-download-geojson.php
+++ b/modules/mtl-download-geojson/mtl-download-geojson.php
@@ -28,15 +28,15 @@ function get_download_button($postId) {
 	if($category) {
 		$output .= '
 	<script data-mtl-data-script data-mtl-replace-with="#mtl-geojson-data" id="mtl-geojson-data" type="application/json">
-		{"title_for_geojson": "'.addcslashes(get_the_title($postId), "\"\\\n\r\t").'",
-		"content_for_geojson": "'.addcslashes(get_the_content(null, false, $postId), "\"\\\n\r\t").'",
+		{"title_for_geojson": "'.str_replace(["[", "]"], ["[[", "]]"], addcslashes(get_the_title($postId), "\"\\\n\r\t")).'",
+		"content_for_geojson": "'.str_replace(["[", "]"], ["[[", "]]"], addcslashes(get_the_content(null, false, $postId), "\"\\\n\r\t")).'",
 		"author_for_geojson": "'.get_post_field( 'post_author', $postId ).'",
 		"date_for_geojson": "'.get_the_date('', $postId).'",
 		"website_for_geojson": "'.get_bloginfo('url').'",
 		"category_for_geojson": "'.__($category[0]->name, 'my-transit-lines').'",
 		"license_link_for_geojson": "https://creativecommons.org/licenses/by-nc-sa/3.0/de/"}
 	</script>
-	<script type="text/javascript" src="'.get_template_directory_uri().'/modules/mtl-download-geojson/mtl-download-geojson.js?ver='.wp_get_theme()->version.'"></script>'.
+	<script type="text/javascript" src="'.get_template_directory_uri().'/modules/mtl-download-geojson/mtl-download-geojson.js?ver='.wp_get_theme()->version.'" defer></script>'.
 	'<p><a href="" download="'.$postId.'-'.str_replace("\r","\\r",str_replace("\n","\\n",addslashes(get_the_title($postId)))).'.geojson" id="mtl-geojson-download">'.__('Download proposal map data as GeoJSON','my-transit-lines').'</a></p>';
 	}
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://stadtkreation.de/en/wordpress-themes-and-plugins/
 Author: Stadtkreation
 Author URI: https://stadtkreation.de/en/about-us/
 Description: My Transit Lines is a Wordpress theme developed for urban and regional public transit platforms.
-Version: 2.13.5
+Version: 2.13.6
 Tested up to: 6.7.1
 Requires PHP: 7.4
 License: GNU General Public License v2 or later


### PR DESCRIPTION
Shortcodes in the proposal text would be expanded despite being inside a <script> tag, so now all braces are escaped. Also doesn't download an HTML file if something fails anymore, but gives an error message instead.